### PR TITLE
[recently-used] saving the last 5 used ingredients

### DIFF
--- a/CookSmart/CookSmart/CSIngredientGroup.h
+++ b/CookSmart/CookSmart/CSIngredientGroup.h
@@ -19,6 +19,7 @@
 
 - (void)deleteIngredient:(CSIngredient *)ingredient;
 - (void)addIngredient:(CSIngredient*)ingredient;
+- (void)addRecentlyUsedIngredient:(CSIngredient *)ingredient;
 - (void)replaceIngredientAtIndex:(NSUInteger)index withIngredient:(CSIngredient*)ingredient;
 - (NSDictionary *)dictionary;
 

--- a/CookSmart/CookSmart/CSIngredientGroup.m
+++ b/CookSmart/CookSmart/CSIngredientGroup.m
@@ -10,6 +10,8 @@
 #import "CSIngredient.h"
 #import "CSIngredientGroupInternals.h"
 
+static NSUInteger const RECENTLY_USED_COUNT = 5;
+
 @interface CSIngredientGroup ()
 {
     unsigned long _version;
@@ -108,6 +110,23 @@
 {
     _version++;
     [self.ingredients addObject:ingredient];
+}
+
+- (void)addRecentlyUsedIngredient:(CSIngredient *)ingredient
+{
+    _version++;
+    
+    NSUInteger index = [self.ingredients indexOfObject:ingredient];
+    if (index != NSNotFound)
+    {
+        [self.ingredients removeObjectAtIndex:index];
+    }
+    
+    [self.ingredients insertObject:ingredient atIndex:0];
+    if ([self countOfIngredients] > RECENTLY_USED_COUNT)
+    {
+        [self.ingredients removeLastObject];
+    }
 }
 
 - (void)replaceIngredientAtIndex:(NSUInteger)index withIngredient:(CSIngredient*)ingredient

--- a/CookSmart/CookSmart/CSIngredientListVC.m
+++ b/CookSmart/CookSmart/CSIngredientListVC.m
@@ -78,12 +78,6 @@ static const NSUInteger ResetToDefaultsHeight = 40;
     [self.tableView setContentOffset:CGPointMake(0, self.tableView.contentOffset.y + self.searchBar.frame.size.height)];
 }
 
-- (void)viewWillAppear:(BOOL)animated
-{
-    [super viewWillAppear:animated];
-    
-}
-
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
@@ -146,10 +140,14 @@ static const NSUInteger ResetToDefaultsHeight = 40;
 {
     CSIngredientGroup *selectedIngredientGroup = [[self ingredientsToSupplyData] ingredientGroupAtIndex:indexPath.section];
     CSIngredient *selectedIngredient = [selectedIngredientGroup ingredientAtIndex:indexPath.row];
+    
+    [[CSIngredients sharedInstance] addToRecentlyUsed:selectedIngredient];
+    
     if ([selectedIngredientGroup respondsToSelector:@selector(originalIngredientGroup)])
     {
         selectedIngredientGroup = [selectedIngredientGroup performSelector:@selector(originalIngredientGroup) withObject:nil];
     }
+    
     [self.delegate ingredientListVC:self
             selectedIngredientGroup:[[CSIngredients sharedInstance] indexOfIngredientGroup:selectedIngredientGroup]
                     ingredientIndex:[selectedIngredientGroup indexOfIngredient:selectedIngredient]];

--- a/CookSmart/CookSmart/CSIngredients.h
+++ b/CookSmart/CookSmart/CSIngredients.h
@@ -40,6 +40,7 @@ static inline NSString *pathToIngredientsInBundle()
 - (NSUInteger)flattenedCountOfIngredients;
 - (NSUInteger)indexOfIngredientGroup:(CSIngredientGroup *)group;
 
+- (BOOL)addToRecentlyUsed:(CSIngredient *)ingredient;
 - (BOOL)deleteIngredientAtGroupIndex:(NSUInteger)groupIndex ingredientIndex:(NSUInteger)ingredientIndex;
 - (BOOL)addIngredient:(CSIngredient*)newIngr;
 - (BOOL)persist;

--- a/CookSmart/CookSmart/CSIngredients.m
+++ b/CookSmart/CookSmart/CSIngredients.m
@@ -12,6 +12,7 @@
 #import "CSIngredient.h"
 
 #define CUSTOM_GROUP_NAME @"Custom"
+#define RECENTLY_USED_NAME @"Recently Used"
 
 @interface CSIngredients()
 {
@@ -100,6 +101,18 @@ static CSIngredients *sharedInstance;
         [self.ingredientGroups addObject:[CSIngredientGroup ingredientGroupWithDictionary:@{CUSTOM_GROUP_NAME:@[]}]];
     }
     return [self lastIngredientGroup];
+}
+
+- (CSIngredientGroup *)recentlyUsedIngredientGroup
+{
+    CSIngredientGroup *group = [self ingredientGroupAtIndex:0];
+    if (![group.name isEqualToString:RECENTLY_USED_NAME])
+    {
+        //need to create it
+        group = [CSIngredientGroup ingredientGroupWithDictionary:@{RECENTLY_USED_NAME:@[]}];
+        [self.ingredientGroups insertObject:group atIndex:0];
+    }
+    return group;
 }
 
 - (CSIngredient*)ingredientAtGroupIndex:(NSUInteger)groupIndex andIngredientIndex:(NSUInteger)index
@@ -222,6 +235,18 @@ static CSIngredients *sharedInstance;
     // preserved for the next invocation.
     state->state = countOfItemsAlreadyEnumerated;
     return count;
+}
+
+#pragma mark - actions on list
+
+- (BOOL)addToRecentlyUsed:(CSIngredient *)ingredient
+{
+    _version++; //mutation protection for fast enumeration
+    
+    CSIngredientGroup *recentlyUsedGroup = [self recentlyUsedIngredientGroup];
+    [recentlyUsedGroup addRecentlyUsedIngredient:ingredient];
+    
+    return [sharedInstance persist];
 }
 
 - (BOOL)deleteIngredientAtGroupIndex:(NSUInteger)groupIndex ingredientIndex:(NSUInteger)ingredientIndex


### PR DESCRIPTION
I made a `CSRecentlyUsedIngredientGroup` class, so I could override `addIngredient:` method. But that ended up being too messy when trying to imprort the ingredients from the plist on launch. This works!

Let me know what you think.