### PR TITLE
[iOS] Extracting vulgar fractions utility

### DIFF
--- a/CookSmart/CakeTests/DoubleStringUtilsTests.swift
+++ b/CookSmart/CakeTests/DoubleStringUtilsTests.swift
@@ -10,17 +10,31 @@
 import XCTest
 
 class DoubleSringUtilsTests: XCTestCase {
-  override func setUpWithError() throws {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+  // MARK: humanReadableValue
+
+  func test_humanReadableValue_aboveThreshold_roundsDown() {
+    let rawValue = 66.445
+    let result = rawValue.humanReadableValue
+    XCTAssertEqual(result, 66)
   }
 
-  override func tearDownWithError() throws {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+  func test_humanReadableValue_aboveThreshhold_roundsUp() {
+    let rawValue = 104.849998
+    let result = rawValue.humanReadableValue
+    XCTAssertEqual(result, 105)
   }
 
-  func test_humanReadbleValue_aboveThreshold() throws {
-    let value = 66.445
-    let string = value.humanReadableValue
-    XCTAssertEqual(string, "")
+  func test_humanReadableValue_belowThreshold() {
+    let rawValue = 49.45
+    let result = rawValue.humanReadableValue
+    XCTAssertEqual(result, 49.45)
+  }
+
+  // MARK: humanReadableString
+
+  func test_humanReadableString_aboveThreshold() {
+    let rawValue = 66.445
+    let result = rawValue.humanReadableString
+    XCTAssertEqual(result, "66")
   }
 }

--- a/CookSmart/CakeTests/DoubleStringUtilsTests.swift
+++ b/CookSmart/CakeTests/DoubleStringUtilsTests.swift
@@ -10,31 +10,61 @@
 import XCTest
 
 class DoubleSringUtilsTests: XCTestCase {
-  // MARK: humanReadableValue
+  // MARK: roundedValue
 
-  func test_humanReadableValue_aboveThreshold_roundsDown() {
+  func test_roundedValue_aboveThreshold_roundsDown() {
     let rawValue = 66.445
-    let result = rawValue.humanReadableValue
+    let result = rawValue.roundedValue
     XCTAssertEqual(result, 66)
   }
 
-  func test_humanReadableValue_aboveThreshhold_roundsUp() {
+  func test_roundedValue_aboveThreshhold_roundsUp() {
     let rawValue = 104.849998
-    let result = rawValue.humanReadableValue
+    let result = rawValue.roundedValue
     XCTAssertEqual(result, 105)
   }
 
-  func test_humanReadableValue_belowThreshold() {
+  func test_roundedValue_belowThreshold_half() {
     let rawValue = 49.45
-    let result = rawValue.humanReadableValue
-    XCTAssertEqual(result, 49.45)
+    let result = rawValue.roundedValue
+    XCTAssertEqual(result, 49.500)
   }
 
-  // MARK: humanReadableString
+  // MARK: vulgarFractionString
 
-  func test_humanReadableString_aboveThreshold() {
+  func test_vulgarFractionString_aboveThreshold_roundsUp() {
+    let rawValue = 66.7
+    let result = rawValue.vulgarFractionString
+    XCTAssertEqual(result, "67")
+  }
+
+  func test_vulgarFractionString_aboveThreshold_roundsDown() {
     let rawValue = 66.445
-    let result = rawValue.humanReadableString
+    let result = rawValue.vulgarFractionString
     XCTAssertEqual(result, "66")
+  }
+
+  func test_vulgarFractionString_aboveThreshold() {
+    let rawValue = 66.445
+    let result = rawValue.vulgarFractionString
+    XCTAssertEqual(result, "66")
+  }
+
+  func test_vulgarFractionString_belowThreshold_half() {
+    let rawValue = 49.45
+    let result = rawValue.vulgarFractionString
+    XCTAssertEqual(result, "49½")
+  }
+
+  func test_vulgarFractionString_belowThreshold_zero() {
+    let rawValue = 0.05
+    let result = rawValue.vulgarFractionString
+    XCTAssertEqual(result, "0")
+  }
+
+  func test_vulgarFractionString_belowThreshold_eighth() {
+    let rawValue = 0.1
+    let result = rawValue.vulgarFractionString
+    XCTAssertEqual(result, "⅛")
   }
 }

--- a/CookSmart/CakeTests/DoubleStringUtilsTests.swift
+++ b/CookSmart/CakeTests/DoubleStringUtilsTests.swift
@@ -30,6 +30,12 @@ class DoubleSringUtilsTests: XCTestCase {
     XCTAssertEqual(result, 49.500)
   }
 
+  func test_roundedValue_belowThreshold_two() {
+    let rawValue = 1.95
+    let result = rawValue.roundedValue
+    XCTAssertEqual(result, 2)
+  }
+
   // MARK: vulgarFractionString
 
   func test_vulgarFractionString_aboveThreshold_roundsUp() {
@@ -66,5 +72,29 @@ class DoubleSringUtilsTests: XCTestCase {
     let rawValue = 0.1
     let result = rawValue.vulgarFractionString
     XCTAssertEqual(result, "⅛")
+  }
+
+  func test_vulgarFractionString_belowThreshold_quarter() {
+    let rawValue = 1.20
+    let result = rawValue.vulgarFractionString
+    XCTAssertEqual(result, "1¼")
+  }
+
+  func test_vulgarFractionString_belowThreshold_third() {
+    let rawValue = 1.35
+    let result = rawValue.vulgarFractionString
+    XCTAssertEqual(result, "1⅓")
+  }
+
+  func test_vulgarFractionString_belowThreshold_one() {
+    let rawValue = 0.95
+    let result = rawValue.vulgarFractionString
+    XCTAssertEqual(result, "1")
+  }
+
+  func test_vulgarFractionString_belowThreshold_two() {
+    let rawValue = 1.95
+    let result = rawValue.vulgarFractionString
+    XCTAssertEqual(result, "2")
   }
 }

--- a/CookSmart/CookSmart.xcodeproj/project.pbxproj
+++ b/CookSmart/CookSmart.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		77479AF924303D86000CFB0E /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77479AF824303D86000CFB0E /* Fonts.swift */; };
 		774EBD6524426CC2002A59AC /* Double+StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774EBD6424426CC2002A59AC /* Double+StringUtils.swift */; };
 		774EBD77244271DC002A59AC /* DoubleStringUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774EBD67244270C8002A59AC /* DoubleStringUtilsTests.swift */; };
+		774EBD792442A1CE002A59AC /* Fraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774EBD782442A1CE002A59AC /* Fraction.swift */; };
 		80433B2E1BB26C1A006B7A85 /* CSRecentsIngredientGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 80433B2D1BB26C1A006B7A85 /* CSRecentsIngredientGroup.m */; };
 		80433B361BB2731B006B7A85 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 80433B351BB2731B006B7A85 /* Launch Screen.storyboard */; };
 		80592C0518924B010082D4E1 /* CSIngredients.m in Sources */ = {isa = PBXBuildFile; fileRef = 80592C0418924B010082D4E1 /* CSIngredients.m */; };
@@ -93,6 +94,7 @@
 		774EBD67244270C8002A59AC /* DoubleStringUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleStringUtilsTests.swift; sourceTree = "<group>"; };
 		774EBD6D244271D6002A59AC /* CakeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CakeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		774EBD71244271D6002A59AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		774EBD782442A1CE002A59AC /* Fraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fraction.swift; sourceTree = "<group>"; };
 		80433B2C1BB26C1A006B7A85 /* CSRecentsIngredientGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSRecentsIngredientGroup.h; sourceTree = "<group>"; };
 		80433B2D1BB26C1A006B7A85 /* CSRecentsIngredientGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSRecentsIngredientGroup.m; sourceTree = "<group>"; };
 		80433B2F1BB27270006B7A85 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSDKCoreKit.framework; path = CookSmart/FBSDKCoreKit.framework; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 				392D8644242FD0FF002064D6 /* Colors.swift */,
 				77479AF824303D86000CFB0E /* Fonts.swift */,
 				774EBD6424426CC2002A59AC /* Double+StringUtils.swift */,
+				774EBD782442A1CE002A59AC /* Fraction.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -568,6 +571,7 @@
 				77479AEA242FB9C8000CFB0E /* ScaleTile.swift in Sources */,
 				392D8645242FD0FF002064D6 /* Colors.swift in Sources */,
 				80A614DE18BF3D4100A205BB /* CSGlassView.m in Sources */,
+				774EBD792442A1CE002A59AC /* Fraction.swift in Sources */,
 				93F6CCA818AED6050045400D /* CSScaleVC.m in Sources */,
 				931AF96D18C2BAE50018AA8B /* CSUnitCollection.m in Sources */,
 				935DB3AC18B46A28007989D7 /* CSEditIngredientVC.m in Sources */,

--- a/CookSmart/CookSmart/Core/Double+StringUtils.swift
+++ b/CookSmart/CookSmart/Core/Double+StringUtils.swift
@@ -9,75 +9,34 @@
 import Foundation
 
 extension Double {
-  var wholeValue: Double {
+  private var whole: Self { modf(self).0 }
+  private var decimal: Self { modf(self).1 }
+
+  private var roundedWhole: Double {
     guard self < 50.0 else {
       return rounded(FloatingPointRoundingRule.toNearestOrEven)
     }
 
-    return modf(self).0
+    return whole
   }
 
-  var decimalFraction: Fraction {
+  private var decimalFraction: Fraction {
     guard self < 50.0 else { return .zero }
-    return Fraction(value: modf(self).1)
+    return Fraction(value: decimal)
   }
 
   var roundedValue: Double {
-    wholeValue + decimalFraction.rawValue
+    roundedWhole + decimalFraction.rawValue
   }
 
   var vulgarFractionString: String {
-    let whole = wholeValue
-    let fraction = decimalFraction
+    let rounded = roundedValue
+    let whole = rounded.whole
+    let fraction = rounded.decimalFraction
 
     if whole == 0, fraction != .zero {
       return fraction.string
     }
-
     return String(format: "%.0f", whole) + fraction.string
-  }
-}
-
-enum Fraction: Double, CaseIterable {
-  case zero = 0
-  case eighth = 0.125
-  case quarter = 0.250
-  case third = 0.333
-  case threeEighths = 0.375
-  case half = 0.500
-  case fiveEighths = 0.625
-  case twoThirds = 0.666
-  case threeQuarters = 0.750
-  case sevenEighths = 0.875
-  case one = 1.0
-
-  init(value: Double) {
-    var closestFraction: Fraction = .zero
-    var smallestDifference: Double = 1.0
-
-    for fraction in Fraction.allCases {
-      let difference = fabs(fraction.rawValue - value)
-      if difference < smallestDifference {
-        smallestDifference = difference
-        closestFraction = fraction
-      }
-    }
-
-    self = closestFraction
-  }
-
-  var string: String {
-    switch self {
-    case .eighth: return "⅛"
-    case .quarter: return "¼"
-    case .third: return "⅓"
-    case .threeEighths: return "⅜"
-    case .half: return "½"
-    case .fiveEighths: return "⅝"
-    case .twoThirds: return "⅔"
-    case .threeQuarters: return "¾"
-    case .sevenEighths: return "⅞"
-    case .zero, .one: return ""
-    }
   }
 }

--- a/CookSmart/CookSmart/Core/Double+StringUtils.swift
+++ b/CookSmart/CookSmart/Core/Double+StringUtils.swift
@@ -9,20 +9,75 @@
 import Foundation
 
 extension Double {
-  var humanReadableValue: Double {
+  var wholeValue: Double {
     guard self < 50.0 else {
       return rounded(FloatingPointRoundingRule.toNearestOrEven)
     }
 
-    let wholeNumber = floor(self)
-    let leftover = self - wholeNumber
-
-    // iterate over special fractions to figure out which is closer
-
-    return self
+    return modf(self).0
   }
 
-  var humanReadableString: String {
-    String(format: "%.0f", humanReadableValue)
+  var decimalFraction: Fraction {
+    guard self < 50.0 else { return .zero }
+    return Fraction(value: modf(self).1)
+  }
+
+  var roundedValue: Double {
+    wholeValue + decimalFraction.rawValue
+  }
+
+  var vulgarFractionString: String {
+    let whole = wholeValue
+    let fraction = decimalFraction
+
+    if whole == 0, fraction != .zero {
+      return fraction.string
+    }
+
+    return String(format: "%.0f", whole) + fraction.string
+  }
+}
+
+enum Fraction: Double, CaseIterable {
+  case zero = 0
+  case eighth = 0.125
+  case quarter = 0.250
+  case third = 0.333
+  case threeEighths = 0.375
+  case half = 0.500
+  case fiveEighths = 0.625
+  case twoThirds = 0.666
+  case threeQuarters = 0.750
+  case sevenEighths = 0.875
+  case one = 1.0
+
+  init(value: Double) {
+    var closestFraction: Fraction = .zero
+    var smallestDifference: Double = 1.0
+
+    for fraction in Fraction.allCases {
+      let difference = fabs(fraction.rawValue - value)
+      if difference < smallestDifference {
+        smallestDifference = difference
+        closestFraction = fraction
+      }
+    }
+
+    self = closestFraction
+  }
+
+  var string: String {
+    switch self {
+    case .eighth: return "⅛"
+    case .quarter: return "¼"
+    case .third: return "⅓"
+    case .threeEighths: return "⅜"
+    case .half: return "½"
+    case .fiveEighths: return "⅝"
+    case .twoThirds: return "⅔"
+    case .threeQuarters: return "¾"
+    case .sevenEighths: return "⅞"
+    case .zero, .one: return ""
+    }
   }
 }

--- a/CookSmart/CookSmart/Core/Double+StringUtils.swift
+++ b/CookSmart/CookSmart/Core/Double+StringUtils.swift
@@ -8,25 +8,27 @@
 
 import Foundation
 
+let fractionThreshold: Double = 50.0
+
 extension Double {
-  private var whole: Self { modf(self).0 }
+  private var whole: Int { Int(modf(self).0) }
   private var decimal: Self { modf(self).1 }
 
-  private var roundedWhole: Double {
-    guard self < 50.0 else {
-      return rounded(FloatingPointRoundingRule.toNearestOrEven)
+  private var roundedWhole: Int {
+    guard self < fractionThreshold else {
+      return Int(rounded(FloatingPointRoundingRule.toNearestOrEven))
     }
 
     return whole
   }
 
   private var decimalFraction: Fraction {
-    guard self < 50.0 else { return .zero }
+    guard self < fractionThreshold else { return .zero }
     return Fraction(value: decimal)
   }
 
   var roundedValue: Double {
-    roundedWhole + decimalFraction.rawValue
+    Double(roundedWhole) + decimalFraction.rawValue
   }
 
   var vulgarFractionString: String {
@@ -37,6 +39,6 @@ extension Double {
     if whole == 0, fraction != .zero {
       return fraction.string
     }
-    return String(format: "%.0f", whole) + fraction.string
+    return String(whole) + fraction.string
   }
 }

--- a/CookSmart/CookSmart/Core/Double+StringUtils.swift
+++ b/CookSmart/CookSmart/Core/Double+StringUtils.swift
@@ -9,7 +9,20 @@
 import Foundation
 
 extension Double {
-  var humanReadableValue: String {
-    ""
+  var humanReadableValue: Double {
+    guard self < 50.0 else {
+      return rounded(FloatingPointRoundingRule.toNearestOrEven)
+    }
+
+    let wholeNumber = floor(self)
+    let leftover = self - wholeNumber
+
+    // iterate over special fractions to figure out which is closer
+
+    return self
+  }
+
+  var humanReadableString: String {
+    String(format: "%.0f", humanReadableValue)
   }
 }

--- a/CookSmart/CookSmart/Core/Double+StringUtils.swift
+++ b/CookSmart/CookSmart/Core/Double+StringUtils.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-let fractionThreshold: Double = 50.0
+private let fractionThreshold: Double = 50.0
 
 extension Double {
   private var whole: Int { Int(modf(self).0) }

--- a/CookSmart/CookSmart/Core/Fraction.swift
+++ b/CookSmart/CookSmart/Core/Fraction.swift
@@ -1,0 +1,53 @@
+//
+//  Fraction.swift
+//  cake
+//
+//  Created by Olga Galchenko on 4/11/20.
+//  Copyright © 2020 Olga Galchenko. All rights reserved.
+//
+
+import Foundation
+
+enum Fraction: Double, CaseIterable {
+  case zero = 0
+  case eighth = 0.125
+  case quarter = 0.250
+  case third = 0.333
+  case threeEighths = 0.375
+  case half = 0.500
+  case fiveEighths = 0.625
+  case twoThirds = 0.666
+  case threeQuarters = 0.750
+  case sevenEighths = 0.875
+  case one = 1.0
+
+  init(value: Double) {
+    var closestFraction: Fraction = .zero
+    var smallestDifference: Double = 1.0
+
+    for fraction in Fraction.allCases {
+      let difference = fabs(fraction.rawValue - value)
+      if difference < smallestDifference {
+        smallestDifference = difference
+        closestFraction = fraction
+      }
+    }
+
+    self = closestFraction
+  }
+
+  var string: String {
+    switch self {
+    case .eighth: return "⅛"
+    case .quarter: return "¼"
+    case .third: return "⅓"
+    case .threeEighths: return "⅜"
+    case .half: return "½"
+    case .fiveEighths: return "⅝"
+    case .twoThirds: return "⅔"
+    case .threeQuarters: return "¾"
+    case .sevenEighths: return "⅞"
+    case .zero, .one: return ""
+    }
+  }
+}


### PR DESCRIPTION
In preparation for rewriting `CSScaleVC` in swift, I wanted to extract the method that took values like `35.33333` and turned them into `35⅓`.

Turned into this whole thing (with tests!). 🤷‍♀️ 

Since `CSScaleVC` is still in objc, I can't even replace the old method with this, so it stays for now.