### PR TITLE
Unit Picker Fixes

### DIFF
--- a/CookSmart/CookSmart/UnitPickerView.swift
+++ b/CookSmart/CookSmart/UnitPickerView.swift
@@ -76,19 +76,23 @@ class UnitPickerView: UIView {
   }
 }
 
+// MARK: - UnitPickerScrollView
+
 private class UnitPickerScrollView: UIView {
   private enum Constants {
     static let unitLabelHeight: CGFloat = 40
   }
 
   private let unitCollection: CSUnitCollection
+  private var selectedIndex: UInt
 
   var currentlySelectedUnit: CSUnit {
-    unitCollection.unit(at: UInt(closestLabelIndex))
+    unitCollection.unit(at: selectedIndex)
   }
 
   init(units: CSUnitCollection, selectedUnit: CSUnit) {
     unitCollection = units
+    selectedIndex = unitCollection.index(of: selectedUnit)
     super.init(frame: .zero)
     setupViews()
   }
@@ -126,9 +130,13 @@ private class UnitPickerScrollView: UIView {
   override func layoutSubviews() {
     super.layoutSubviews()
 
-    let scrollViewHeight = scrollView.frame.height
-    unitStackViewTopConstraint?.constant = (scrollViewHeight / 2) - (Constants.unitLabelHeight / 2)
-    unitStackViewBottomConstraint?.constant = -((scrollViewHeight / 2) - (Constants.unitLabelHeight * 3 / 2))
+    let halfScrollViewHeight = scrollView.frame.height / 2
+    let halfUnitLabelHeight = Constants.unitLabelHeight / 2
+    unitStackViewTopConstraint?.constant = halfScrollViewHeight - halfUnitLabelHeight
+    unitStackViewBottomConstraint?.constant = -(halfScrollViewHeight - (halfUnitLabelHeight * 3))
+
+    let selectedIndexOffset = Constants.unitLabelHeight * CGFloat(selectedIndex)
+    scrollView.contentOffset = CGPoint(x: 0, y: selectedIndexOffset)
   }
 
   private func setupViews() {
@@ -136,24 +144,17 @@ private class UnitPickerScrollView: UIView {
     scrollView.delegate = self
 
     addSubview(scrollView)
-    scrollView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-    scrollView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
-    scrollView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
-    scrollView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+    scrollView.constrainToSuperview()
 
     scrollView.addSubview(unitStackView)
+    unitStackView.constrainToSuperview(anchors: [.leading, .trailing, .width])
     unitStackViewTopConstraint = unitStackView.topAnchor.constraint(equalTo: scrollView.topAnchor)
     unitStackViewTopConstraint?.isActive = true
-    unitStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor).isActive = true
-    unitStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor).isActive = true
     unitStackViewBottomConstraint = unitStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor)
     unitStackViewBottomConstraint?.isActive = true
-    unitStackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor).isActive = true
 
     addSubview(centerLineView)
-    centerLineView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
-    centerLineView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-    centerLineView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+    centerLineView.constrainToSuperview(anchors: [.centerY, .leading, .trailing])
 
     addUnitLabels()
   }
@@ -172,15 +173,18 @@ private class UnitPickerScrollView: UIView {
       }
   }
 
-  private var closestLabelIndex: Int {
-    Int(round(scrollView.contentOffset.y / Constants.unitLabelHeight))
+  private func updateSelectedIndex() {
+    selectedIndex = UInt(round(scrollView.contentOffset.y / Constants.unitLabelHeight))
   }
 
   private func scrollToNearestLabel() {
-    let yOffset = CGFloat(closestLabelIndex) * Constants.unitLabelHeight
+    updateSelectedIndex()
+    let yOffset = CGFloat(selectedIndex) * Constants.unitLabelHeight
     scrollView.setContentOffset(CGPoint(x: 0, y: yOffset), animated: true)
   }
 }
+
+// MARK: UIScrollViewDelegate
 
 extension UnitPickerScrollView: UIScrollViewDelegate {
   func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
@@ -190,5 +194,9 @@ extension UnitPickerScrollView: UIScrollViewDelegate {
   func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
     guard !decelerate else { return }
     scrollToNearestLabel()
+  }
+
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    scrollView.contentOffset = CGPoint(x: 0, y: scrollView.contentOffset.y)
   }
 }

--- a/CookSmart/CookSmart/UnitPickerView.swift
+++ b/CookSmart/CookSmart/UnitPickerView.swift
@@ -197,6 +197,6 @@ extension UnitPickerScrollView: UIScrollViewDelegate {
   }
 
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    scrollView.contentOffset = CGPoint(x: 0, y: scrollView.contentOffset.y)
+    scrollView.contentOffset.x = 0
   }
 }


### PR DESCRIPTION
This makes the unit picker correctly select the current units when it's initialized and disables horizontal scrolling on the unit picker.